### PR TITLE
Fix install.py Unicode error on Windows (cp1252 encoding)

### DIFF
--- a/install.py
+++ b/install.py
@@ -34,18 +34,18 @@ def install():
         ])
 
         print("\n" + "="*60)
-        print("✓ ComfyUI-SDNQ installation complete!")
+        print("[OK] ComfyUI-SDNQ installation complete!")
         print("="*60)
         print("\nNext steps:")
         print("1. Restart ComfyUI")
-        print("2. Look for 'SDNQ Model Loader' under loaders/SDNQ")
+        print("2. Look for 'SDNQ Sampler' under sampling/SDNQ")
         print("3. Browse models: https://huggingface.co/collections/Disty0/sdnq")
         print("\n" + "="*60 + "\n")
 
         return True
 
     except subprocess.CalledProcessError as e:
-        print(f"\n✗ Installation failed: {e}")
+        print(f"\n[ERROR] Installation failed: {e}")
         print("\nTry manual installation:")
         print(f"  pip install -r {requirements_file}")
         return False


### PR DESCRIPTION
Problem: Windows console uses cp1252 encoding which can't display Unicode checkmarks (✓/✗)
Error: UnicodeEncodeError: 'charmap' codec can't encode character '\u2713'

Fix: Replace Unicode characters with ASCII-safe alternatives
- ✓ → [OK]
- ✗ → [ERROR]

Also updated node name reference: 'SDNQ Model Loader' → 'SDNQ Sampler'