### PR TITLE
fix(security):path traversal in SDNQModelQuantizer

### DIFF
--- a/nodes/quantizer.py
+++ b/nodes/quantizer.py
@@ -100,10 +100,14 @@ class SDNQModelQuantizer:
             ) from e
 
         # Validate inputs
-        if not output_name or output_name.strip() == "":
+        if not output_name or not output_name.strip():
             raise ValueError("output_name cannot be empty")
 
-        output_name = output_name.strip()
+        # CRITICAL: Sanitize the output name to prevent path traversal.
+        # os.path.basename strips all directory information, leaving only the filename.
+        sanitized_name = os.path.basename(output_name.strip())
+        if not sanitized_name or sanitized_name in (".", ".."):
+            raise ValueError("Invalid output_name. Please use a valid filename.")
 
         # Determine output directory (ComfyUI models folder)
         try:
@@ -123,7 +127,7 @@ class SDNQModelQuantizer:
         sdnq_dir = base_dir / "sdnq"
         sdnq_dir.mkdir(parents=True, exist_ok=True)
 
-        output_path = sdnq_dir / output_name
+        output_path = sdnq_dir / sanitized_name
 
         # Check if output already exists
         if output_path.exists():


### PR DESCRIPTION
Critical: Path Traversal Vulnerability in SDNQModelQuantizer
The SDNQModelQuantizer node has a path traversal vulnerability. The output_name input is used to construct a file path without proper sanitization. A malicious user (or a user who pastes a malicious string from the internet) could provide an input like ../../../../.ssh/authorized_keys to overwrite arbitrary files on the system with the permissions of the ComfyUI process.

Fix: Sanitize the output_name by stripping any directory information from it, ensuring files can only be written inside the intended ComfyUI/models/diffusers/sdnq/ directory. Using os.path.basename is a robust way to achieve this.
