### PR TITLE
fix: Expand image inputs to 4, improve error handling, fix SDNQ matmul

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,7 @@ pip install --upgrade git+https://github.com/huggingface/diffusers.git
 - `lora_strength`: -5.0 to +5.0 (1.0 = full strength)
 
 **Image Editing** (optional - connect LoadImage node):
-- `image1`: Source image for editing (Qwen-Image-Edit, ChronoEdit, etc.)
-- `image2`: Optional second image for multi-image editing
+- `image1`, `image2`, `image3`, `image4`: Source images for editing (Qwen-Image-Edit, ChronoEdit, etc.)
 - `image_resize`: Auto-resize inputs (512px-1536px options)
 
 **Outputs**: `IMAGE` (connects to SaveImage, Preview, etc.)

--- a/__init__.py
+++ b/__init__.py
@@ -42,7 +42,7 @@ def comfy_entrypoint():
     return {
         "node_class_mappings": NODE_CLASS_MAPPINGS,
         "node_display_name_mappings": NODE_DISPLAY_NAME_MAPPINGS,
-        "version": "1.2.0",
+        "version": "1.3.0",
         "author": "ComfyUI-SDNQ Contributors",
         "description": "SDNQ quantized model support for ComfyUI",
         "license": "Apache-2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui-sdnq"
-version = "1.2.0"
+version = "1.3.0"
 description = "ComfyUI custom node pack for loading SDNQ quantized models"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,25 +1,31 @@
+# ComfyUI-SDNQ Dependencies
+# ========================
+# These are MINIMUM version requirements. If you already have newer versions
+# installed (e.g., diffusers from GitHub), pip will NOT downgrade them.
+#
+# For latest model support (FLUX.2, Z-Image-Turbo, Qwen-Image-Edit-2511):
+#   pip install --upgrade diffusers
+# Or install from GitHub if the model isn't yet in the PyPI release:
+#   pip install --upgrade git+https://github.com/huggingface/diffusers.git
+
 # SDNQ quantization engine (includes quantized models support)
-# Note: Install from GitHub for latest features
 sdnq>=0.1.0
 
-# Diffusers and transformers
-# IMPORTANT: diffusers 0.36.0 not yet on PyPI - install from GitHub:
-#   pip install git+https://github.com/huggingface/diffusers.git
-# Or wait for PyPI release and use: diffusers>=0.36.0
-diffusers>=0.36.0
+# Diffusers - minimum version for most models
+# Newer versions may be required for latest models (see README)
+diffusers>=0.30.0
 
 # Transformers for text encoding
 transformers>=4.40.0
 
 # HuggingFace Hub integration
-# Let package manager resolve version based on diffusers/transformers requirements
 huggingface-hub>=0.20.0
 
-# Model serialization (latest stable)
-safetensors>=0.7.0
+# Model serialization
+safetensors>=0.4.0
 
 # PyTorch (required but usually pre-installed with ComfyUI)
 torch>=2.0.0
 
-# Acceleration utilities (latest stable)
-accelerate>=1.12.0
+# Acceleration utilities
+accelerate>=0.25.0


### PR DESCRIPTION
Changes:
- Add image3 and image4 inputs for multi-image editing (4 total like EA_LMStudio)
- Handle 'image' parameter not supported gracefully - fallback to text-to-image
- Detect pipelines that REQUIRE images and show clear error message
- Remove text_encoder from quantized_matmul (VL models have non-8-divisible dims)
- Simplify requirements.txt to avoid forcing version downgrades
- Bump version to 1.3.0