### PR TITLE
fix: Add [tool.comfy] section, create blank image for Qwen T2I mode

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -42,7 +42,7 @@ def comfy_entrypoint():
     return {
         "node_class_mappings": NODE_CLASS_MAPPINGS,
         "node_display_name_mappings": NODE_DISPLAY_NAME_MAPPINGS,
-        "version": "1.3.0",
+        "version": "1.4.0",
         "author": "ComfyUI-SDNQ Contributors",
         "description": "SDNQ quantized model support for ComfyUI",
         "license": "Apache-2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "comfyui-sdnq"
-version = "1.3.0"
+version = "1.4.0"
 description = "ComfyUI custom node pack for loading SDNQ quantized models"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -45,6 +45,13 @@ Repository = "https://github.com/EnragedAntelope/comfyui-sdnq"
 Issues = "https://github.com/EnragedAntelope/comfyui-sdnq/issues"
 "SDNQ Repository" = "https://github.com/Disty0/sdnq"
 "Pre-quantized Models" = "https://huggingface.co/collections/Disty0/sdnq"
+
+[tool.comfy]
+# Required for ComfyUI Registry publishing
+# Get your publisher ID from https://comfyregistry.org
+PublisherId = "enragedantelope"
+DisplayName = "SDNQ Model Loader"
+Icon = ""
 
 [tool.setuptools]
 packages = ["nodes", "core"]


### PR DESCRIPTION
Changes:
- Add [tool.comfy] section to pyproject.toml for ComfyUI registry (PublisherId, DisplayName required for registry updates)
- Create blank white image for Qwen/Edit pipelines without image input This enables text-to-image mode with pipelines that require an image
- Show pipeline name in generation logs for better debugging
- Bump version to 1.4.0

Fixes: ComfyUI registry not updating since 12/18/2025