### PR TITLE
fix: Restructure pyproject.toml and simplify workflow for registry pu…

### DIFF
--- a/.github/workflows/publish_action.yml
+++ b/.github/workflows/publish_action.yml
@@ -1,33 +1,18 @@
 name: Publish to Comfy registry
 on:
+  workflow_dispatch:
   push:
-    branches: [main]
+    branches:
+      - main
     paths:
       - "pyproject.toml"
-  workflow_dispatch:
 
 jobs:
   publish-node:
+    name: Publish Custom Node to registry
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Detect version change
-        id: version_check
-        run: |
-          set -e
-          OLD_VERSION=$(git show HEAD^:pyproject.toml 2>/dev/null | grep '^version' | sed 's/.*"//' | sed 's/".*//')
-          NEW_VERSION=$(grep '^version' pyproject.toml | sed 's/.*"//' | sed 's/".*//')
-          echo "old=${OLD_VERSION}"
-          echo "new=${NEW_VERSION}"
-          if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
-          else
-            echo "changed=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Publish Custom Node
-        if: steps.version_check.outputs.changed == 'true'
-        uses: Comfy-Org/publish-node-action@main
+      - uses: Comfy-Org/publish-node-action@main
         with:
           personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,24 +1,14 @@
 [project]
 name = "comfyui-sdnq"
-version = "1.4.02"
 description = "ComfyUI custom node pack for loading SDNQ quantized models"
+version = "1.4.03"
 license = {file = "LICENSE"}
 
+[project.urls]
+Repository = "https://github.com/EnragedAntelope/comfyui-sdnq"
+# Used by Comfy Registry https://comfyregistry.org
+
 [tool.comfy]
-# Required for ComfyUI Registry publishing
-# Get your publisher ID from https://comfyregistry.org
 PublisherId = "enragedantelope"
 DisplayName = "SDNQ Model Loader"
 Icon = ""
-keywords = [
-    "comfyui",
-    "sdnq",
-    "quantization",
-    "stable-diffusion",
-    "diffusers"
-]
-[project.urls]
-Homepage = "https://github.com/EnragedAntelope/comfyui-sdnq"
-Repository = "https://github.com/EnragedAntelope/comfyui-sdnq"
-Issues = "https://github.com/EnragedAntelope/comfyui-sdnq/issues"
-"Pre-quantized Models" = "https://huggingface.co/collections/Disty0/sdnq"


### PR DESCRIPTION
…blishing

This fixes the ComfyUI registry publishing issues by:

1. pyproject.toml changes:
   - Reorder sections to match successful examples: [project] → [project.urls] → [tool.comfy]
   - Simplify [project.urls] to only include Repository with registry comment
   - Remove keywords from [tool.comfy] section
   - Reorder [project] fields: name → description → version → license
   - Bump version to 1.4.03

2. GitHub workflow changes:
   - Remove custom version detection logic
   - Simplify to match official publish-node-action example
   - Let the action handle version detection internally

Structure now matches successful examples from ComfyUI-Manager and ComfyUI-Impact-Pack, as well as the working EA_LMStudio repo.