### PR TITLE
fix: Remove redundant torch.compile option - SDNQ handles this intern…

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Run large models like FLUX.2, FLUX.1, SD3.5, Qwen-Image, and more on consumer ha
 - **50-75% VRAM savings** with SDNQ quantization
 - **Memory modes**: GPU (fastest), balanced (12-16GB), lowvram (8GB)
 - **LoRA support**, image editing, 14 schedulers
-- **Performance options**: xFormers, torch.compile, VAE tiling
+- **Performance options**: Triton acceleration, xFormers, VAE tiling
 
 ## Installation
 
@@ -43,9 +43,11 @@ Browse all models: [Disty0's SDNQ Collection](https://huggingface.co/collections
 
 ## Performance
 
-For best speed, install Triton:
+For best speed (30-80% faster), install Triton:
 - **Linux**: `pip install triton`
 - **Windows**: `pip install triton-windows`
+
+Triton enables optimized quantized matmul operations. Enabled by default when available.
 
 **Scheduler tip**: Use `FlowMatchEulerDiscreteScheduler` for FLUX/SD3/Qwen. Use `DPMSolverMultistepScheduler` for SDXL/SD1.5.
 
@@ -57,8 +59,6 @@ pip install --upgrade transformers diffusers
 ```
 
 **Out of memory** → Try `balanced` or `lowvram` memory mode, or use uint4 models.
-
-**torch.compile crashes** → Disable it. Experimental feature, especially on Windows.
 
 **Slow performance** → Install Triton (see above), or try `use_xformers=True`.
 


### PR DESCRIPTION
…ally

Research findings (see SD.Next wiki and SDNQ repo):
- SDNQ uses torch.compile internally for the dequantization step via apply_sdnq_options_to_model(use_quantized_matmul=True)
- Adding a separate torch.compile() on the entire model is redundant
- Caused cudaMallocAsync errors due to CUDA graphs + ComfyUI memory allocator conflict (PyTorch issue #158641, ComfyUI issue #6831)

Changes:
- Remove use_torch_compile parameter from node UI, method signatures
- Remove redundant torch.compile code block
- Update tooltip to clarify use_quantized_matmul uses torch.compile internally
- Update README to remove torch.compile references

The Triton acceleration (30-80% speedup) is still available via use_quantized_matmul=True, which is the proper SDNQ implementation.